### PR TITLE
fix typo in logged warning

### DIFF
--- a/src/sumo/modes/run/run.py
+++ b/src/sumo/modes/run/run.py
@@ -409,7 +409,7 @@ def _run_factorization(sparsity: float, k: int, sumo_run: SumoRun):
     maxiter_proc = round((sum([step == sumo_run.max_iter for step in steps_reached]) / len(steps_reached)) * 100, 3)
     eta_logger.info("#Reached maximum number of iterations in {}% of runs".format(maxiter_proc))
     if maxiter_proc >= 90:
-        eta_logger.warning("Consider increasing -max_iter and deacreasing -tol to achieve better accuracy")
+        eta_logger.warning("Consider increasing -max_iter and decreasing -tol to achieve better accuracy")
     out_arrays['steps'] = np.array([steps_reached])
 
     if sumo_run.log == "DEBUG":


### PR DESCRIPTION
There was a small typo in a logged warning which I fixed.
I'm happy to alternatively merge it into the development branch; however the development branch does not contain all commits from master.